### PR TITLE
python 3.9 as this as pip by default in nueeg.yaml

### DIFF
--- a/workflow-template/nueeg.yml
+++ b/workflow-template/nueeg.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
@bhydemi let's go on 3.9 as minimum requirement as this has pip installed by default.